### PR TITLE
Fix several errors in ca_ES.php

### DIFF
--- a/src/Locales/ca_ES.php
+++ b/src/Locales/ca_ES.php
@@ -6,15 +6,15 @@
 return array(
     "months"        => explode('_', 'gener_febrer_març_abril_maig_juny_juliol_agost_setembre_octubre_novembre_desembre'),
     "monthsShort"   => explode('_', 'gen._febr._mar._abr._mai._jun._jul._ag._set._oct._nov._des.'),
-    "weekdays"      => explode('_', 'diumenge_dilluns_dimarts_dimecres_dijous_divendres_dissabte'),
-    "weekdaysShort" => explode('_', 'dg._dl._dt._dc._dj._dv._ds.'),
+    "weekdays"      => explode('_', 'dilluns_dimarts_dimecres_dijous_divendres_dissabte_diumenge'),
+    "weekdaysShort" => explode('_', 'dl._dt._dc._dj._dv._ds._dg.'),
     "calendar"      => array(
         "sameDay"  => '[avui]',
         "nextDay"  => '[demà]',
         "lastDay"  => '[ahir]',
         "lastWeek" => '[el] l',
         "sameElse" => 'l',
-        "withTime" => function (Moment $moment) { return '[a' . ($moment->getHour() !== 1 ? ' les' : null) . '] H:i'; },
+        "withTime" => function (Moment $moment) { return '[a' . ($moment->getHour() != 1 ? ' les ' : ' l\'') . ']G.i [h]'; },
         "default"  => 'd/m/Y',
     ),
     "relativeTime"  => array(
@@ -37,19 +37,19 @@ return array(
 
         switch ($number) {
             case 1:
-                $ouput = 'r';
+                $output = 'r';
                 break;
             case 2:
-                $ouput = 'n';
+                $output = 'n';
                 break;
             case 3:
-                $ouput = 'r';
+                $output = 'r';
                 break;
             case 4:
-                $ouput = 't';
+                $output = 't';
                 break;
             default:
-                $ouput = 'è';
+                $output = 'è';
                 break;
         }
 


### PR DESCRIPTION
Some breaking errors fixed:
- Typo in ordinals function ($ouput should be $output).
- Wrong order in weekdays and weekdaysShort (arrays should begin with "dilluns" ("Monday").
Improvement:
- Time format: in Catalan, "." is better than ":" as a separator between hours and minutes. Also, suffix " h" is added. When the time was 1.00, the wrong article was being used because the identical comparison was not working.