### PR TITLE
Improved time format in de_DE.php

### DIFF
--- a/src/Locales/de_DE.php
+++ b/src/Locales/de_DE.php
@@ -14,7 +14,7 @@ return array(
         "lastDay"  => '[Gestern]',
         "lastWeek" => '[Letzten] l',
         "sameElse" => 'l',
-        "withTime" => '[um] H:i',
+        "withTime" => '[um] H:i [Uhr]',
         "default"  => 'd.m.Y',
     ),
     "relativeTime"  => array(


### PR DESCRIPTION
Added common " Uhr" suffix to german time format.